### PR TITLE
[codex] Add anonymous cheers to waffle cards

### DIFF
--- a/api/_lib/wafflesDb.ts
+++ b/api/_lib/wafflesDb.ts
@@ -9,6 +9,7 @@ export type WaffleRow = {
   flavor: Waffle['flavor']
   message: string
   created_at: Date | string
+  celebration_count: number
 }
 
 const connectionString =
@@ -18,6 +19,20 @@ export const hasDatabaseConfig = Boolean(connectionString)
 
 let pool: Pool | null = null
 let tableReadyPromise: Promise<void> | null = null
+
+const WAFFLE_SELECT = `
+  SELECT
+    waffles.id,
+    waffles.sender_name,
+    waffles.recipient_name,
+    waffles.flavor,
+    waffles.message,
+    waffles.created_at,
+    COALESCE(COUNT(waffle_celebrations.waffle_id), 0)::int AS celebration_count
+  FROM waffles
+  LEFT JOIN waffle_celebrations
+    ON waffle_celebrations.waffle_id = waffles.id
+`
 
 export const getPool = () => {
   if (!connectionString) {
@@ -37,7 +52,7 @@ export const getPool = () => {
   return pool
 }
 
-export const ensureWafflesTable = async () => {
+export const ensureWaffleTables = async () => {
   if (!tableReadyPromise) {
     tableReadyPromise = getPool()
       .query(`
@@ -50,10 +65,59 @@ export const ensureWafflesTable = async () => {
           created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )
       `)
+      .then(() =>
+        getPool().query(`
+        CREATE TABLE IF NOT EXISTS waffle_celebrations (
+          waffle_id TEXT NOT NULL REFERENCES waffles(id) ON DELETE CASCADE,
+          browser_token TEXT NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          PRIMARY KEY (waffle_id, browser_token)
+        )
+      `)
+      )
       .then(() => undefined)
   }
 
   await tableReadyPromise
+}
+
+export const listWaffleRows = async (limit = 100) => {
+  const result = await getPool().query<WaffleRow>(
+    `
+      ${WAFFLE_SELECT}
+      GROUP BY
+        waffles.id,
+        waffles.sender_name,
+        waffles.recipient_name,
+        waffles.flavor,
+        waffles.message,
+        waffles.created_at
+      ORDER BY waffles.created_at DESC
+      LIMIT $1
+    `,
+    [limit]
+  )
+
+  return result.rows
+}
+
+export const getWaffleRowById = async (waffleId: string) => {
+  const result = await getPool().query<WaffleRow>(
+    `
+      ${WAFFLE_SELECT}
+      WHERE waffles.id = $1
+      GROUP BY
+        waffles.id,
+        waffles.sender_name,
+        waffles.recipient_name,
+        waffles.flavor,
+        waffles.message,
+        waffles.created_at
+    `,
+    [waffleId]
+  )
+
+  return result.rows[0] ?? null
 }
 
 export const mapWaffleRowToDomain = (row: WaffleRow): Waffle => ({
@@ -63,4 +127,5 @@ export const mapWaffleRowToDomain = (row: WaffleRow): Waffle => ({
   flavor: row.flavor,
   message: row.message,
   createdAt: new Date(row.created_at).toISOString(),
+  celebrationCount: row.celebration_count,
 })

--- a/api/waffles.ts
+++ b/api/waffles.ts
@@ -2,11 +2,12 @@ import { randomUUID } from 'node:crypto'
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import type { SendWaffleInput } from '../src/domain/waffles.js'
 import {
-  ensureWafflesTable,
+  ensureWaffleTables,
+  getWaffleRowById,
   getPool,
   hasDatabaseConfig,
+  listWaffleRows,
   mapWaffleRowToDomain,
-  type WaffleRow,
 } from './_lib/wafflesDb.js'
 
 // Keep runtime validation local to the API function so the server bundle does
@@ -56,21 +57,12 @@ export default async function handler(
   }
 
   try {
-    await ensureWafflesTable()
+    await ensureWaffleTables()
     const pool = getPool()
 
     if (request.method === 'GET') {
-      const result = await pool.query<WaffleRow>(
-        `
-          SELECT id, sender_name, recipient_name, flavor, message, created_at
-          FROM waffles
-          ORDER BY created_at DESC
-          LIMIT 100
-        `
-      )
-
       return response.status(200).json({
-        waffles: result.rows.map(mapWaffleRowToDomain),
+        waffles: (await listWaffleRows()).map(mapWaffleRowToDomain),
       })
     }
 
@@ -83,7 +75,7 @@ export default async function handler(
       })
     }
 
-    const result = await pool.query<WaffleRow>(
+    const result = await pool.query<{ id: string }>(
       `
         INSERT INTO waffles (
           id,
@@ -94,7 +86,7 @@ export default async function handler(
           created_at
         )
         VALUES ($1, $2, $3, $4, $5, NOW())
-        RETURNING id, sender_name, recipient_name, flavor, message, created_at
+        RETURNING id
       `,
       [
         randomUUID(),
@@ -105,8 +97,14 @@ export default async function handler(
       ]
     )
 
+    const waffle = await getWaffleRowById(result.rows[0]?.id ?? '')
+
+    if (!waffle) {
+      throw new Error('Unable to load the created waffle right now.')
+    }
+
     return response.status(201).json({
-      waffle: mapWaffleRowToDomain(result.rows[0]),
+      waffle: mapWaffleRowToDomain(waffle),
     })
   } catch (error) {
     const message =

--- a/api/waffles/[id]/celebrate.ts
+++ b/api/waffles/[id]/celebrate.ts
@@ -1,0 +1,100 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import {
+  ensureWaffleTables,
+  getPool,
+  getWaffleRowById,
+  hasDatabaseConfig,
+  mapWaffleRowToDomain,
+} from '../../_lib/wafflesDb.js'
+
+type CelebrateRequestBody = {
+  browserToken?: unknown
+}
+
+const readBody = (request: VercelRequest) => {
+  if (typeof request.body === 'string') {
+    return JSON.parse(request.body) as CelebrateRequestBody
+  }
+
+  return (request.body ?? {}) as CelebrateRequestBody
+}
+
+const readWaffleId = (request: VercelRequest) => {
+  const { id } = request.query
+
+  if (Array.isArray(id)) {
+    return id[0] ?? ''
+  }
+
+  return typeof id === 'string' ? id : ''
+}
+
+export default async function handler(
+  request: VercelRequest,
+  response: VercelResponse
+) {
+  response.setHeader('Content-Type', 'application/json')
+
+  if (!hasDatabaseConfig) {
+    return response.status(503).json({
+      error:
+        'Shared persistence is not configured. Add DATABASE_URL to enable the live team feed.',
+    })
+  }
+
+  if (request.method !== 'POST') {
+    response.setHeader('Allow', 'POST')
+    return response.status(405).json({ error: 'Method not allowed.' })
+  }
+
+  const waffleId = readWaffleId(request)
+  const { browserToken } = readBody(request)
+  const normalizedBrowserToken =
+    typeof browserToken === 'string' ? browserToken.trim() : ''
+
+  if (!waffleId) {
+    return response.status(400).json({ error: 'A waffle id is required.' })
+  }
+
+  if (!normalizedBrowserToken) {
+    return response.status(400).json({
+      error: 'A browser token is required to celebrate a waffle.',
+    })
+  }
+
+  try {
+    await ensureWaffleTables()
+    const pool = getPool()
+    const existingWaffle = await getWaffleRowById(waffleId)
+
+    if (!existingWaffle) {
+      return response.status(404).json({
+        error: 'That waffle could not be found.',
+      })
+    }
+
+    await pool.query(
+      `
+        INSERT INTO waffle_celebrations (waffle_id, browser_token, created_at)
+        VALUES ($1, $2, NOW())
+        ON CONFLICT (waffle_id, browser_token) DO NOTHING
+      `,
+      [waffleId, normalizedBrowserToken]
+    )
+
+    const waffle = await getWaffleRowById(waffleId)
+
+    return response.status(200).json({
+      waffle: mapWaffleRowToDomain(waffle),
+    })
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Unable to celebrate that waffle right now.'
+
+    return response.status(500).json({
+      error: message,
+    })
+  }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import App from './App'
@@ -24,6 +24,7 @@ const mockMatchMedia = (matches: boolean) => {
 
 describe('App', () => {
   afterEach(() => {
+    window.localStorage.clear()
     vi.restoreAllMocks()
   })
 
@@ -34,6 +35,40 @@ describe('App', () => {
     expect(
       screen.getByText(SEEDED_WAFFLES[1].message)
     ).toBeInTheDocument()
+    expect(screen.getByText('2 cheers')).toBeInTheDocument()
+  })
+
+  it('lets the viewer celebrate a waffle once', async () => {
+    const user = userEvent.setup()
+
+    render(<App repository={createMockWaffleRepository()} />)
+
+    const cardTitle = await screen.findByText(/Alex sent a waffle to Taylor/i)
+    const card = cardTitle.closest('article')
+
+    expect(card).not.toBeNull()
+
+    await user.click(within(card as HTMLElement).getByRole('button', { name: /Celebrate/i }))
+
+    expect(within(card as HTMLElement).getByRole('button', { name: /Celebrated/i })).toBeDisabled()
+    expect(within(card as HTMLElement).getByText('1 cheer')).toBeInTheDocument()
+  })
+
+  it('renders previously celebrated waffles as completed for this browser', async () => {
+    window.localStorage.setItem(
+      'vvaffle:celebrated-waffle-ids',
+      JSON.stringify(['waffle-001'])
+    )
+
+    render(<App repository={createMockWaffleRepository()} />)
+
+    const cardTitle = await screen.findByText(/Ryan sent a waffle to Priya/i)
+    const card = cardTitle.closest('article')
+
+    expect(card).not.toBeNull()
+    expect(
+      within(card as HTMLElement).getByRole('button', { name: /Celebrated/i })
+    ).toBeDisabled()
   })
 
   it('lets the user send a new waffle into the feed', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { type SendWaffleInput, type Waffle } from './domain/waffles'
 import { HomePage } from './features/home/HomePage'
 import {
+  markWaffleCelebrated,
+  syncViewerCelebrations,
+} from './lib/celebrationState'
+import {
   createDefaultWaffleRepository,
   type WaffleRepository,
 } from './lib/waffleRepository'
@@ -35,7 +39,7 @@ export default function App({ repository }: AppProps) {
       try {
         await repo.seedDemoData?.()
         const nextWaffles = await repo.listWaffles()
-        setWaffles(nextWaffles)
+        setWaffles(syncViewerCelebrations(nextWaffles))
       } catch (error) {
         const message =
           error instanceof Error
@@ -56,7 +60,7 @@ export default function App({ repository }: AppProps) {
     try {
       await repo.sendWaffle(input)
       const nextWaffles = await repo.listWaffles()
-      setWaffles(nextWaffles)
+      setWaffles(syncViewerCelebrations(nextWaffles))
     } catch (error) {
       const message =
         error instanceof Error
@@ -67,11 +71,35 @@ export default function App({ repository }: AppProps) {
     }
   }
 
+  const handleCelebrate = async (waffleId: string) => {
+    setErrorMessage(null)
+
+    try {
+      const nextWaffle = await repo.celebrateWaffle(waffleId)
+      markWaffleCelebrated(waffleId)
+      setWaffles((currentWaffles) =>
+        currentWaffles.map((waffle) =>
+          waffle.id === waffleId
+            ? { ...nextWaffle, viewerHasCelebrated: true }
+            : waffle
+        )
+      )
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unable to celebrate that waffle right now.'
+      setErrorMessage(message)
+      throw error
+    }
+  }
+
   return (
     <HomePage
       errorMessage={errorMessage}
       figmaFileUrl={DEFAULT_FIGMA_FILE_URL}
       isLoading={isLoading}
+      onCelebrate={handleCelebrate}
       onSend={handleSend}
       tagline={DEFAULT_TAGLINE}
       waffles={waffles}

--- a/src/domain/waffles.ts
+++ b/src/domain/waffles.ts
@@ -25,6 +25,8 @@ export type Waffle = {
   flavor: WaffleFlavor
   message: string
   createdAt: CreatedAt
+  celebrationCount: number
+  viewerHasCelebrated?: boolean
 }
 
 export type SendWaffleInput = {
@@ -42,6 +44,7 @@ export const SEEDED_WAFFLES: Waffle[] = [
     flavor: 'Classic Buttermilk',
     message: 'For untangling the debugger mystery before coffee.',
     createdAt: '2026-03-31T15:00:00.000Z',
+    celebrationCount: 2,
   },
   {
     id: 'waffle-002',
@@ -50,6 +53,7 @@ export const SEEDED_WAFFLES: Waffle[] = [
     flavor: 'Chocolate Confetti',
     message: 'You turned the prototype review into a tiny party.',
     createdAt: '2026-03-31T14:15:00.000Z',
+    celebrationCount: 1,
   },
   {
     id: 'waffle-003',
@@ -58,5 +62,6 @@ export const SEEDED_WAFFLES: Waffle[] = [
     flavor: 'Blueberry Blitz',
     message: 'For the Figma cleanup pass that made the round-trip sing.',
     createdAt: '2026-03-31T13:20:00.000Z',
+    celebrationCount: 0,
   },
 ]

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -12,6 +12,7 @@ type HomePageProps = {
   errorMessage: string | null
   figmaFileUrl?: string
   isLoading: boolean
+  onCelebrate: (waffleId: string) => Promise<void>
   onSend: (input: SendWaffleInput) => Promise<void>
   tagline: string
   waffles: Waffle[]
@@ -21,6 +22,7 @@ export function HomePage({
   errorMessage,
   figmaFileUrl,
   isLoading,
+  onCelebrate,
   onSend,
   tagline,
   waffles,
@@ -75,6 +77,7 @@ export function HomePage({
         <div className="home-feed-column">
           <WaffleFeedSection
             isLoading={isLoading}
+            onCelebrate={onCelebrate}
             onOpenComposer={handleOpenComposer}
             waffles={waffles}
           />

--- a/src/features/home/WaffleComposerSection.tsx
+++ b/src/features/home/WaffleComposerSection.tsx
@@ -137,7 +137,7 @@ export function WaffleComposerSection({
               <p aria-live="polite" className="feature-status">
                 {status === 'sent'
                   ? 'Waffle sent to the team feed.'
-                  : 'Recognition is shared publicly so appreciation stays visible.'}
+                  : 'Recognition stays public so teammates can notice it and add a cheer.'}
               </p>
             </div>
           </form>

--- a/src/features/home/WaffleFeedSection.tsx
+++ b/src/features/home/WaffleFeedSection.tsx
@@ -5,6 +5,7 @@ import {
   m,
   useReducedMotion,
 } from 'motion/react'
+import { useState } from 'react'
 import { type Waffle } from '../../domain/waffles'
 import { formatFriendlyTimestamp } from '../../lib/time'
 import { Badge } from '../../ui/Badge'
@@ -15,16 +16,34 @@ import { Stack } from '../../ui/Stack'
 
 type WaffleFeedSectionProps = {
   isLoading: boolean
+  onCelebrate: (waffleId: string) => Promise<void>
   onOpenComposer: () => void
   waffles: Waffle[]
 }
 
 export function WaffleFeedSection({
   isLoading,
+  onCelebrate,
   onOpenComposer,
   waffles,
 }: WaffleFeedSectionProps) {
   const shouldReduceMotion = useReducedMotion()
+  const [celebratingWaffleId, setCelebratingWaffleId] = useState<string | null>(null)
+
+  const handleCelebrate = async (waffleId: string) => {
+    setCelebratingWaffleId(waffleId)
+
+    try {
+      await onCelebrate(waffleId)
+    } finally {
+      setCelebratingWaffleId((currentId) =>
+        currentId === waffleId ? null : currentId
+      )
+    }
+  }
+
+  const formatCelebrationCount = (count: number) =>
+    `${count} ${count === 1 ? 'cheer' : 'cheers'}`
 
   return (
     <section>
@@ -104,6 +123,26 @@ export function WaffleFeedSection({
                           </h3>
                           <p className="feed-card-message">{waffle.message}</p>
                         </Stack>
+                        <div className="feed-card-footer">
+                          <button
+                            className="feed-card-celebrate-button"
+                            disabled={
+                              waffle.viewerHasCelebrated ||
+                              celebratingWaffleId === waffle.id
+                            }
+                            onClick={() => void handleCelebrate(waffle.id)}
+                            type="button"
+                          >
+                            {celebratingWaffleId === waffle.id
+                              ? 'Celebrating...'
+                              : waffle.viewerHasCelebrated
+                                ? 'Celebrated'
+                                : 'Celebrate'}
+                          </button>
+                          <p className="feed-card-celebration-count" aria-live="polite">
+                            {formatCelebrationCount(waffle.celebrationCount)}
+                          </p>
+                        </div>
                       </Panel>
                     </m.div>
                   ))}

--- a/src/lib/__tests__/waffleRepository.test.ts
+++ b/src/lib/__tests__/waffleRepository.test.ts
@@ -13,6 +13,14 @@ describe('createMockWaffleRepository', () => {
     expect(waffles).toHaveLength(SEEDED_WAFFLES.length)
     expect(waffles[0].createdAt >= waffles[1].createdAt).toBe(true)
   })
+
+  it('increments the celebration count for a waffle', async () => {
+    const repository = createMockWaffleRepository()
+
+    const updatedWaffle = await repository.celebrateWaffle('waffle-003')
+
+    expect(updatedWaffle.celebrationCount).toBe(1)
+  })
 })
 
 describe('createApiWaffleRepository', () => {
@@ -52,6 +60,7 @@ describe('createApiWaffleRepository', () => {
             flavor: WAFFLE_FLAVORS[0],
             message: 'Thanks for helping unblock the launch.',
             createdAt,
+            celebrationCount: 0,
           },
         }),
         {
@@ -81,5 +90,39 @@ describe('createApiWaffleRepository', () => {
     )
     expect(waffle.createdAt).toBe(createdAt)
     expect(waffle.sender.name).toBe('Avery')
+  })
+
+  it('posts celebrate requests and returns the updated waffle', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          waffle: {
+            ...SEEDED_WAFFLES[0],
+            celebrationCount: 3,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    )
+
+    const repository = createApiWaffleRepository({
+      baseUrl: 'https://example.com',
+      fetchImpl,
+      getBrowserToken: () => 'browser-123',
+    })
+
+    const waffle = await repository.celebrateWaffle('waffle-001')
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://example.com/api/waffles/waffle-001/celebrate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ browserToken: 'browser-123' }),
+      })
+    )
+    expect(waffle.celebrationCount).toBe(3)
   })
 })

--- a/src/lib/celebrationState.ts
+++ b/src/lib/celebrationState.ts
@@ -1,0 +1,96 @@
+import { type Waffle } from '../domain/waffles'
+
+const CELEBRATED_WAFFLE_IDS_KEY = 'vvaffle:celebrated-waffle-ids'
+const BROWSER_TOKEN_KEY = 'vvaffle:browser-token'
+
+let memoryCelebratedWaffleIds = new Set<string>()
+let memoryBrowserToken: string | null = null
+
+const getStorage = () => {
+  try {
+    return globalThis.localStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+const parseCelebratedIds = (value: string | null) => {
+  if (!value) {
+    return new Set<string>()
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (!Array.isArray(parsed)) {
+      return new Set<string>()
+    }
+
+    return new Set(
+      parsed.filter((item): item is string => typeof item === 'string')
+    )
+  } catch {
+    return new Set<string>()
+  }
+}
+
+const createBrowserToken = () =>
+  globalThis.crypto?.randomUUID?.() ??
+  `browser-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+
+export const getCelebratedWaffleIds = () => {
+  const storage = getStorage()
+
+  if (!storage) {
+    return new Set(memoryCelebratedWaffleIds)
+  }
+
+  return parseCelebratedIds(storage.getItem(CELEBRATED_WAFFLE_IDS_KEY))
+}
+
+export const markWaffleCelebrated = (waffleId: string) => {
+  const nextCelebratedIds = getCelebratedWaffleIds()
+  nextCelebratedIds.add(waffleId)
+  memoryCelebratedWaffleIds = nextCelebratedIds
+
+  const storage = getStorage()
+  if (!storage) {
+    return
+  }
+
+  storage.setItem(
+    CELEBRATED_WAFFLE_IDS_KEY,
+    JSON.stringify([...nextCelebratedIds])
+  )
+}
+
+export const syncViewerCelebrations = (waffles: Waffle[]) => {
+  const celebratedIds = getCelebratedWaffleIds()
+
+  return waffles.map((waffle) => ({
+    ...waffle,
+    viewerHasCelebrated: celebratedIds.has(waffle.id),
+  }))
+}
+
+export const getBrowserToken = () => {
+  const storage = getStorage()
+
+  if (!storage) {
+    if (!memoryBrowserToken) {
+      memoryBrowserToken = createBrowserToken()
+    }
+
+    return memoryBrowserToken
+  }
+
+  const existingToken = storage.getItem(BROWSER_TOKEN_KEY)
+  if (existingToken) {
+    memoryBrowserToken = existingToken
+    return existingToken
+  }
+
+  const nextToken = memoryBrowserToken ?? createBrowserToken()
+  memoryBrowserToken = nextToken
+  storage.setItem(BROWSER_TOKEN_KEY, nextToken)
+  return nextToken
+}

--- a/src/lib/waffleRepository.ts
+++ b/src/lib/waffleRepository.ts
@@ -1,8 +1,10 @@
 import { SEEDED_WAFFLES, type SendWaffleInput, type Waffle } from '../domain/waffles'
+import { getBrowserToken } from './celebrationState'
 
 export interface WaffleRepository {
   listWaffles(): Promise<Waffle[]>
   sendWaffle(input: SendWaffleInput): Promise<Waffle>
+  celebrateWaffle(waffleId: string): Promise<Waffle>
   seedDemoData?(): Promise<void>
 }
 
@@ -14,6 +16,7 @@ const normalizeWaffle = (waffle: Waffle): Waffle => ({
   sender: { name: waffle.sender.name.trim() },
   recipient: { name: waffle.recipient.name.trim() },
   message: waffle.message.trim(),
+  celebrationCount: Math.max(0, waffle.celebrationCount ?? 0),
 })
 
 const toDomainWaffle = (input: SendWaffleInput): Waffle => ({
@@ -23,6 +26,7 @@ const toDomainWaffle = (input: SendWaffleInput): Waffle => ({
   flavor: input.flavor,
   message: input.message.trim(),
   createdAt: new Date().toISOString(),
+  celebrationCount: 0,
 })
 
 export const createMockWaffleRepository = (
@@ -42,6 +46,28 @@ export const createMockWaffleRepository = (
       waffles = [nextWaffle, ...waffles]
       return nextWaffle
     },
+    async celebrateWaffle(waffleId) {
+      let updatedWaffle: Waffle | null = null
+
+      waffles = waffles.map((waffle) => {
+        if (waffle.id !== waffleId) {
+          return waffle
+        }
+
+        updatedWaffle = {
+          ...waffle,
+          celebrationCount: waffle.celebrationCount + 1,
+        }
+
+        return updatedWaffle
+      })
+
+      if (!updatedWaffle) {
+        throw new Error('Unable to find that waffle right now.')
+      }
+
+      return updatedWaffle
+    },
     async seedDemoData() {
       if (waffles.length === 0) {
         waffles = [...SEEDED_WAFFLES]
@@ -53,6 +79,7 @@ export const createMockWaffleRepository = (
 type ApiRepositoryOptions = {
   baseUrl?: string
   fetchImpl?: typeof fetch
+  getBrowserToken?: () => string | null
 }
 
 const resolveApiUrl = (path: string, baseUrl?: string) =>
@@ -70,6 +97,7 @@ const parseErrorMessage = async (response: Response) => {
 export const createApiWaffleRepository = ({
   baseUrl,
   fetchImpl = fetch,
+  getBrowserToken: getBrowserTokenImpl = getBrowserToken,
 }: ApiRepositoryOptions = {}): WaffleRepository => {
   return {
     async listWaffles() {
@@ -90,6 +118,26 @@ export const createApiWaffleRepository = ({
         },
         body: JSON.stringify(input),
       })
+
+      if (!response.ok) {
+        throw new Error(await parseErrorMessage(response))
+      }
+
+      const payload = (await response.json()) as { waffle: Waffle }
+      return normalizeWaffle(payload.waffle)
+    },
+    async celebrateWaffle(waffleId) {
+      const browserToken = getBrowserTokenImpl()
+      const response = await fetchImpl(
+        resolveApiUrl(`/api/waffles/${encodeURIComponent(waffleId)}/celebrate`, baseUrl),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ browserToken }),
+        }
+      )
 
       if (!response.ok) {
         throw new Error(await parseErrorMessage(response))

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -167,6 +167,52 @@
   line-height: 1.65;
 }
 
+.feed-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--color-border);
+}
+
+.feed-card-celebrate-button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+  cursor: pointer;
+}
+
+.feed-card-celebrate-button:hover:not(:disabled) {
+  color: var(--color-text);
+}
+
+.feed-card-celebrate-button:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 3px;
+}
+
+.feed-card-celebrate-button:disabled {
+  color: var(--color-text-subtle);
+  cursor: default;
+  opacity: 1;
+}
+
+.feed-card-celebration-count {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
 @media (max-width: 900px) {
   .home-layout {
     grid-template-columns: 1fr;
@@ -195,6 +241,14 @@
   }
 
   .feature-form-footer > .ui-button {
+    width: 100%;
+  }
+
+  .feed-card-footer {
+    align-items: flex-start;
+  }
+
+  .feed-card-celebration-count {
     width: 100%;
   }
 }

--- a/src/test/apiHandlers.test.ts
+++ b/src/test/apiHandlers.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import wafflesHandler from '../../api/waffles'
+import celebrateHandler from '../../api/waffles/[id]/celebrate'
+
+const {
+  ensureWaffleTables,
+  listWaffleRows,
+  getWaffleRowById,
+  query,
+} = vi.hoisted(() => ({
+  ensureWaffleTables: vi.fn(),
+  listWaffleRows: vi.fn(),
+  getWaffleRowById: vi.fn(),
+  query: vi.fn(),
+}))
+
+vi.mock('../../api/_lib/wafflesDb.js', () => ({
+  ensureWaffleTables,
+  getPool: () => ({ query }),
+  getWaffleRowById,
+  hasDatabaseConfig: true,
+  listWaffleRows,
+  mapWaffleRowToDomain: (row: {
+    id: string
+    sender_name: string
+    recipient_name: string
+    flavor: string
+    message: string
+    created_at: string
+    celebration_count: number
+  }) => ({
+    id: row.id,
+    sender: { name: row.sender_name },
+    recipient: { name: row.recipient_name },
+    flavor: row.flavor,
+    message: row.message,
+    createdAt: row.created_at,
+    celebrationCount: row.celebration_count,
+  }),
+}))
+
+const createResponse = () => {
+  const state = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: null as unknown,
+  }
+
+  const response = {
+    setHeader: vi.fn((name: string, value: string) => {
+      state.headers[name] = value
+    }),
+    status: vi.fn((code: number) => {
+      state.statusCode = code
+      return response
+    }),
+    json: vi.fn((payload: unknown) => {
+      state.body = payload
+      return response
+    }),
+  }
+
+  return { response, state }
+}
+
+describe('waffles api handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns celebration counts from the list endpoint', async () => {
+    listWaffleRows.mockResolvedValue([
+      {
+        id: 'waffle-001',
+        sender_name: 'Ryan',
+        recipient_name: 'Priya',
+        flavor: 'Classic Buttermilk',
+        message: 'For untangling the debugger mystery before coffee.',
+        created_at: '2026-03-31T15:00:00.000Z',
+        celebration_count: 2,
+      },
+    ])
+
+    const { response, state } = createResponse()
+
+    await wafflesHandler(
+      { method: 'GET', body: null } as never,
+      response as never
+    )
+
+    expect(ensureWaffleTables).toHaveBeenCalled()
+    expect(state.statusCode).toBe(200)
+    expect(state.body).toEqual({
+      waffles: [
+        expect.objectContaining({
+          id: 'waffle-001',
+          celebrationCount: 2,
+        }),
+      ],
+    })
+  })
+
+  it('celebrates a waffle once per browser token and returns the updated count', async () => {
+    query.mockResolvedValue({ rows: [] })
+    getWaffleRowById.mockResolvedValue({
+      id: 'waffle-001',
+      sender_name: 'Ryan',
+      recipient_name: 'Priya',
+      flavor: 'Classic Buttermilk',
+      message: 'For untangling the debugger mystery before coffee.',
+      created_at: '2026-03-31T15:00:00.000Z',
+      celebration_count: 3,
+    })
+
+    const { response, state } = createResponse()
+
+    await celebrateHandler(
+      {
+        method: 'POST',
+        body: { browserToken: 'browser-123' },
+        query: { id: 'waffle-001' },
+      } as never,
+      response as never
+    )
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (waffle_id, browser_token) DO NOTHING'),
+      ['waffle-001', 'browser-123']
+    )
+    expect(state.statusCode).toBe(200)
+    expect(state.body).toEqual({
+      waffle: expect.objectContaining({
+        id: 'waffle-001',
+        celebrationCount: 3,
+      }),
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add anonymous cheers to waffle cards with one celebrate action per browser
- persist cheer counts in the API-backed feed and enforce uniqueness with a browser token plus `waffle_celebrations` table
- sync local browser celebration state so cheered waffles stay marked as celebrated after refresh
- update the feed card presentation so the celebrate action reads like an inline text link and the cheer count is larger and bolder

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
