### PR TITLE
Apply Solar Velvet theme and logo

### DIFF
--- a/src/assets/vvaffleLogo.ts
+++ b/src/assets/vvaffleLogo.ts
@@ -1,0 +1,2 @@
+export const vvaffleLogoSrc =
+  'https://www.figma.com/api/mcp/asset/0ff97b01-c662-45ed-91fe-7da0e829b30e'

--- a/src/features/home/HeroSection.tsx
+++ b/src/features/home/HeroSection.tsx
@@ -1,3 +1,4 @@
+import { vvaffleLogoSrc } from '../../assets/vvaffleLogo'
 import { Button } from '../../ui/Button'
 import { Panel } from '../../ui/Panel'
 import { Stack } from '../../ui/Stack'
@@ -17,9 +18,7 @@ export function HeroSection({
     <section className="hero-section">
       <Panel as="section" className="hero-panel">
         <Stack gap="lg">
-          <div className="hero-logo" aria-label="vvaffle placeholder logo">
-            vv
-          </div>
+          <img className="hero-logo" alt="vvaffle logo" src={vvaffleLogoSrc} />
 
           <p className="hero-tagline">{tagline}</p>
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -23,19 +23,11 @@
 }
 
 .hero-logo {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--size-hero-logo);
-  height: var(--size-hero-logo);
-  border: 1px solid var(--color-border-strong);
-  border-radius: var(--radius-lg);
-  background: var(--color-surface-muted);
-  color: var(--color-text-muted);
-  font-size: 1.5rem;
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  text-transform: lowercase;
+  display: block;
+  width: min(calc(var(--size-hero-logo) * 1.4), 100%);
+  height: auto;
+  aspect-ratio: 228 / 194;
+  object-fit: cover;
 }
 
 .hero-tagline {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -6,25 +6,25 @@
     ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas,
     'Liberation Mono', 'Courier New', monospace;
 
-  --color-bg: #ffffff;
-  --color-page-background: #ffffff;
-  --color-surface: #ffffff;
-  --color-surface-muted: #f5f5f5;
-  --color-surface-raised: #fafafa;
-  --color-border: #d4d4d8;
-  --color-border-strong: #3f3f46;
-  --color-text: #09090b;
-  --color-text-muted: #52525b;
-  --color-text-subtle: #71717a;
-  --color-inverse: #fafafa;
-  --color-focus: #18181b;
-  --color-accent: #27272a;
-  --color-accent-muted: #e4e4e7;
-  --color-accent-contrast: #fafafa;
-  --color-success: #166534;
-  --color-warning: #a16207;
-  --color-danger: #b91c1c;
-  --color-scrim: rgb(0 0 0 / 0.18);
+  --color-bg: #fffbf4;
+  --color-page-background: #fffbf4;
+  --color-surface: #fffbf4;
+  --color-surface-muted: #ffe2b8;
+  --color-surface-raised: #fff0df;
+  --color-border: #f6b923;
+  --color-border-strong: #522719;
+  --color-text: #110607;
+  --color-text-muted: #6d3a26;
+  --color-text-subtle: #8a4e31;
+  --color-inverse: #fff0df;
+  --color-focus: #210c0a;
+  --color-accent: #371710;
+  --color-accent-muted: #f1c27d;
+  --color-accent-contrast: #fff0df;
+  --color-success: #5f7648;
+  --color-warning: #e0901a;
+  --color-danger: #983838;
+  --color-scrim: rgb(17 6 7 / 0.18);
 
   --radius-sm: 0.5rem;
   --radius-md: 0.75rem;
@@ -52,7 +52,7 @@
 
   --page-max-width: 72rem;
   --z-overlay: 20;
-  --overlay-scrim: rgb(0 0 0 / 0.18);
+  --overlay-scrim: rgb(17 6 7 / 0.18);
   --motion-fast: 160ms;
 }
 


### PR DESCRIPTION
## Summary
- apply the Solar Velvet semantic palette in the app token source
- replace the hero placeholder mark with the new Figma logo asset
- adjust hero logo styling for the image-based mark

## Verification
- npm run build
- npm run test:run